### PR TITLE
Add a factory for creating repositories

### DIFF
--- a/src/Tystr/RestOrm/Metadata/Metadata.php
+++ b/src/Tystr/RestOrm/Metadata/Metadata.php
@@ -3,6 +3,7 @@
 namespace Tystr\RestOrm\Metadata;
 
 use Tystr\RestOrm\Exception\InvalidArgumentException;
+use Tystr\RestOrm\Repository\Repository;
 use ReflectionClass;
 
 /**
@@ -29,6 +30,11 @@ class Metadata
      * @var string
      */
     private $embeddedRel;
+
+    /**
+     * @var string
+     */
+    private $repositoryClass;
 
     /**
      * @param ReflectionClass $reflClass
@@ -106,5 +112,21 @@ class Metadata
     public function setEmbeddedRel($embeddedRel)
     {
         $this->embeddedRel = $embeddedRel;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRepositoryClass()
+    {
+        return $this->repositoryClass ?: Repository::class;
+    }
+
+    /**
+     * @param string $repositoryClass
+     */
+    public function setRepositoryClass($repositoryClass)
+    {
+        $this->repositoryClass = $repositoryClass;
     }
 }

--- a/src/Tystr/RestOrm/Repository/RepositoryFactory.php
+++ b/src/Tystr/RestOrm/Repository/RepositoryFactory.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tystr\RestOrm\Repository;
+
+use GuzzleHttp\ClientInterface;
+use Tystr\RestOrm\Exception\InvalidArgumentException;
+use Tystr\RestOrm\Metadata\Registry;
+use Tystr\RestOrm\Request\Factory as RequestFactory;
+use Tystr\RestOrm\Response\ResponseMapperInterface;
+
+/**
+ * @author Tyler Stroud <tyler@tylerstroud.com>
+ */
+class RepositoryFactory implements RepositoryFactoryInterface
+{
+    /**
+     * @var RepositoryInterface[]
+     */
+    private $repositories = [];
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var RequestFactory
+     */
+    private $requestFactory;
+
+    /**
+     * @var ResponseMapperInterface
+     */
+    private $responseMapper;
+
+    /**
+     * @var Registry
+     */
+    private $metadataRegistry;
+
+    /**
+     * @param ClientInterface         $client
+     * @param RequestFactory          $requestFactory
+     * @param ResponseMapperInterface $responseMapper
+     * @param Registry                $metadataRegistry
+     */
+    public function __construct(
+        ClientInterface $client,
+        RequestFactory $requestFactory,
+        ResponseMapperInterface $responseMapper,
+        Registry $metadataRegistry
+    ) {
+        $this->client = $client;
+        $this->requestFactory = $requestFactory;
+        $this->responseMapper = $responseMapper;
+        $this->metadataRegistry = $metadataRegistry;
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return RepositoryInterface
+     */
+    public function getRepository($class)
+    {
+        if (!class_exists($class)) {
+            throw new InvalidArgumentException(
+                sprintf('Class "%s" does not exist or could not be autoloaded.', $class)
+            );
+        }
+
+        if (!isset($this->repositories[$class])) {
+            $this->repositories[$class] = $this->createRepository($class);
+        }
+
+        return $this->repositories[$class];
+    }
+
+    /**
+     * @param $class
+     *
+     * @return RepositoryInterface
+     */
+    private function createRepository($class)
+    {
+        $metadata = $this->metadataRegistry->getMetadataForClass($class);
+        $repositoryClass = $metadata->getRepositoryClass();
+
+        return new $repositoryClass($this->client, $this->requestFactory, $this->responseMapper, $class);
+    }
+}

--- a/src/Tystr/RestOrm/Repository/RepositoryFactoryInterface.php
+++ b/src/Tystr/RestOrm/Repository/RepositoryFactoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tystr\RestOrm\Repository;
+
+/**
+ * @author Tyler Stroud <tyler@tylerstroud.com>
+ */
+interface RepositoryFactoryInterface
+{
+    /**
+     * @param string $class
+     *
+     * @return RepositoryInterface
+     */
+    public function getRepository($class);
+}

--- a/tests/Tystr/RestOrm/Repository/RepositoryFactoryTest.php
+++ b/tests/Tystr/RestOrm/Repository/RepositoryFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tystr\RestOrm\Repository;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use JMS\Serializer\SerializerBuilder;
+use Tystr\RestOrm\Metadata\Metadata;
+use Tystr\RestOrm\Model\Blog;
+use Tystr\RestOrm\Response\StandardResponseMapper;
+
+/**
+ * @author Tyler Stroud <tyler@tylerstroud.com>
+ */
+class RepositoryFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $client;
+    protected $requestFactory;
+    protected $responseMapper;
+    protected $metadataRegistry;
+    protected $factory;
+
+    public function setUp()
+    {
+        $this->client = new Client();
+        $this->requestFactory = $this->getMockBuilder('Tystr\RestOrm\Request\Factory')->disableOriginalConstructor()->getMock();
+        $this->responseMapper = $this->getMockBuilder('Tystr\RestOrm\Response\ResponseMapperInterface')->getMock();
+        $this->metadataRegistry = $this->getMockBuilder('Tystr\RestOrm\Metadata\Registry')->getMock();
+        $this->factory = new RepositoryFactory(
+            $this->client,
+            $this->requestFactory,
+            $this->responseMapper,
+            $this->metadataRegistry
+        );
+    }
+
+    public function testGetRepository()
+    {
+        $metadata = new Metadata(new \ReflectionClass('Tystr\RestOrm\Model\Blog'));
+        $metadata->setRepositoryClass('Tystr\RestOrm\Repository\Repository');
+        $this->metadataRegistry->expects($this->once())
+            ->method('getMetadataForClass')
+            ->with('Tystr\RestOrm\Model\Blog')
+            ->willReturn($metadata);
+
+        $repository = $this->factory->getRepository('Tystr\RestOrm\Model\Blog');
+        $this->assertInstanceOf('Tystr\RestOrm\Repository\Repository', $repository);
+        $this->assertSame($repository, $this->factory->getRepository('Tystr\RestOrm\Model\Blog'));
+    }
+}


### PR DESCRIPTION
This allows you to set up your factory with all the dependencies once, and simply call `getRepository()` to create repositories.
