### PR TITLE
Allow passing requirements in the request factory methods

### DIFF
--- a/src/Tystr/RestOrm/Request/Factory.php
+++ b/src/Tystr/RestOrm/Request/Factory.php
@@ -63,17 +63,18 @@ class Factory
      *
      * @param object $object
      * @param array  $parameters
+     * @param array  $requirements
      *
      * @return Request
      */
-    public function createSaveRequest($object, array $parameters = [])
+    public function createSaveRequest($object, array $parameters = [], array $requirements = [])
     {
         $metadata = $this->metadataRegistry->getMetadataForClass(get_class($object));
         if (null === $id = $metadata->getIdentifierValue($object)) {
             // Identifier is null so this is a new entity
             return new Request(
                 'POST',
-                $this->urlGenerator->getCreateUrl($metadata->getResource(), $parameters),
+                $this->urlGenerator->getCreateUrl($metadata->getResource(), $parameters, $requirements),
                 ['Content-Type' => $this->getContentTypeHeader()],
                 $this->serializer->serialize($object, $this->format, SerializationContext::create()->setGroups('Default'))
             );
@@ -82,7 +83,7 @@ class Factory
         // Identifier is set so we are modifying an exiting entity
         return new Request(
             'PUT',
-            $this->urlGenerator->getModifyUrl($metadata->getResource(), $id, $parameters),
+            $this->urlGenerator->getModifyUrl($metadata->getResource(), $id, $parameters, $requirements),
             ['Content-Type' => $this->getContentTypeHeader()],
             $this->serializer->serialize($object, $this->format, SerializationContext::create()->setGroups('Default'))
         );
@@ -92,16 +93,17 @@ class Factory
      * @param string $class
      * @param string $id
      * @param array  $parameters
+     * @param array  $requirements
      *
      * @return Request
      */
-    public function createFindOneRequest($class, $id, array $parameters = [])
+    public function createFindOneRequest($class, $id, array $parameters = [], array $requirements = [])
     {
         $metadata = $this->metadataRegistry->getMetadataForClass($class);
 
         return new Request(
             'GET',
-            $this->urlGenerator->getFindOneUrl($metadata->getResource(), $id, $parameters),
+            $this->urlGenerator->getFindOneUrl($metadata->getResource(), $id, $parameters, $requirements),
             ['Content-Type' => $this->getContentTypeHeader()]
         );
     }
@@ -109,16 +111,17 @@ class Factory
     /**
      * @param string $class
      * @param array  $parameters
+     * @param array  $requirements
      *
      * @return Request
      */
-    public function createFindAllRequest($class, array $parameters = [])
+    public function createFindAllRequest($class, array $parameters = [], array $requirements = [])
     {
         $metadata = $this->metadataRegistry->getMetadataForClass($class);
 
         return new Request(
             'GET',
-            $this->urlGenerator->getFindAllUrl($metadata->getResource(), $parameters),
+            $this->urlGenerator->getFindAllUrl($metadata->getResource(), $parameters, $requirements),
             ['Content-Type' => $this->getContentTypeHeader()]
         );
     }
@@ -126,10 +129,11 @@ class Factory
     /**
      * @param object $object
      * @param array  $parameters
+     * @param array  $requirements
      *
      * @return Request
      */
-    public function createDeleteRequest($object, array $parameters = [])
+    public function createDeleteRequest($object, array $parameters = [], array $requirements = [])
     {
         $metadata = $this->metadataRegistry->getMetadataForClass(get_class($object));
 
@@ -138,7 +142,8 @@ class Factory
             $this->urlGenerator->getRemoveUrl(
                 $metadata->getResource(),
                 $metadata->getIdentifierValue($object),
-                $parameters
+                $parameters,
+                $requirements
             ),
             ['Content-Type' => $this->getContentTypeHeader()]
         );

--- a/tests/Tystr/RestOrm/Model/Post.php
+++ b/tests/Tystr/RestOrm/Model/Post.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tystr\RestOrm\Model;
+
+use JMS\Serializer\Annotation\Type;
+use Tystr\RestOrm\Annotation\Id;
+use Tystr\RestOrm\Annotation\Resource;
+
+/**
+ * @Resource("blogs/{{blogId}}/posts", repositoryClass="Tystr\RestOrm\Repository\PostRepository")
+ */
+class Post
+{
+    /**
+     * @Id()
+     * @Type("integer")
+     */
+    public $id;
+
+    /**
+     * @Type("string")
+     */
+    public $body;
+}

--- a/tests/Tystr/RestOrm/Repository/PostRepository.php
+++ b/tests/Tystr/RestOrm/Repository/PostRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tystr\RestOrm\Repository;
+
+/**
+ * @author Laura Gonzalez <lauradgh@gmail.com>
+ */
+class PostRepository extends Repository
+{
+}


### PR DESCRIPTION
Requirements are not currently being passed to the request factory methods, the UrlGenerator needs them to render url with URL requirements.
