### PR TITLE
Allow repository instantiation to be overridden

### DIFF
--- a/src/Tystr/RestOrm/Repository/RepositoryFactory.php
+++ b/src/Tystr/RestOrm/Repository/RepositoryFactory.php
@@ -77,6 +77,17 @@ class RepositoryFactory implements RepositoryFactoryInterface
     }
 
     /**
+     * Instantiate repository
+     *
+     * @param $class
+     * @return RepositoryInterface
+     */
+    protected function instantiateRepository($class)
+    {
+        return new $class($this->client, $this->requestFactory, $this->responseMapper, $class);
+    }
+
+    /**
      * @param $class
      *
      * @return RepositoryInterface
@@ -86,7 +97,7 @@ class RepositoryFactory implements RepositoryFactoryInterface
         $metadata = $this->metadataRegistry->getMetadataForClass($class);
         $repositoryClass = $metadata->getRepositoryClass();
 
-        $repository = new $repositoryClass($this->client, $this->requestFactory, $this->responseMapper, $class);
+        $repository = $this->instantiateRepository($repositoryClass);
 
         if (!$repository instanceof RepositoryInterface) {
             throw new InvalidArgumentException(


### PR DESCRIPTION
I have some usecases where our repositories need additional dependencies but we're using your factory and cannot currently add dependencies. So there are a few options.
- Just create our own factory. I don't like this as much since you may add more logic to your factory that we want too.
- Change your `RepositoryFactory::createRepository()` to protected. This is better but I think this method has logic that shouldn't be touched.
- This PR which just adds a protected method for the actual repository instantiation. This allows us to do this.

```
use Tystr\RestOrm\Repository\RepositoryFactory;

class OurFactory extends RepositoryFactory
{
    private $foo;

    public function __construct(
        ClientInterface $client,
        RequestFactory $requestFactory,
        ResponseMapperInterface $responseMapper,
        Registry $metadataRegistry,
        FooDependency $foo
    ) {
        parent::__construct($client, $requestFactory, $responseMapper, $metadataRegistry);
        $this->foo = $foo;
    }

    protected function instantiateRepository($class)
    {
        // we pass $this->foo;
        return new $class($client, $requestFactory, $responseMapper, $metadataRegistry, $this->foo);
    }
}
```

I'm open to any other ideas too.
