### PR TITLE
Fix broken factory instantiateRepository() API

### DIFF
--- a/src/Tystr/RestOrm/Repository/RepositoryFactory.php
+++ b/src/Tystr/RestOrm/Repository/RepositoryFactory.php
@@ -16,27 +16,27 @@ class RepositoryFactory implements RepositoryFactoryInterface
     /**
      * @var RepositoryInterface[]
      */
-    private $repositories = [];
+    protected $repositories = [];
 
     /**
      * @var ClientInterface
      */
-    private $client;
+    protected $client;
 
     /**
      * @var RequestFactory
      */
-    private $requestFactory;
+    protected $requestFactory;
 
     /**
      * @var ResponseMapperInterface
      */
-    private $responseMapper;
+    protected $responseMapper;
 
     /**
      * @var Registry
      */
-    private $metadataRegistry;
+    protected $metadataRegistry;
 
     /**
      * @param ClientInterface         $client
@@ -77,14 +77,21 @@ class RepositoryFactory implements RepositoryFactoryInterface
     }
 
     /**
-     * Instantiate repository
+     * Instantiate and return repository
      *
-     * @param $class
+     * @param string $repositoryClass
+     * @param string $modelClass
+     *
      * @return RepositoryInterface
      */
-    protected function instantiateRepository($class)
+    protected function instantiateRepository($repositoryClass, $modelClass)
     {
-        return new $class($this->client, $this->requestFactory, $this->responseMapper, $class);
+        return new $repositoryClass(
+            $this->client,
+            $this->requestFactory,
+            $this->responseMapper,
+            $modelClass
+        );
     }
 
     /**
@@ -97,7 +104,10 @@ class RepositoryFactory implements RepositoryFactoryInterface
         $metadata = $this->metadataRegistry->getMetadataForClass($class);
         $repositoryClass = $metadata->getRepositoryClass();
 
-        $repository = $this->instantiateRepository($repositoryClass);
+        $repository = $this->instantiateRepository(
+            $repositoryClass,
+            $class
+        );
 
         if (!$repository instanceof RepositoryInterface) {
             throw new InvalidArgumentException(

--- a/tests/Tystr/RestOrm/Repository/ChildRepository.php
+++ b/tests/Tystr/RestOrm/Repository/ChildRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tystr\RestOrm\Repository;
+
+use GuzzleHttp\ClientInterface;
+use Tystr\RestOrm\Request\Factory;
+use Tystr\RestOrm\Response\ResponseMapperInterface;
+
+/**
+ * Custom child repository
+ *
+ * @author John Pancoast <john.p@zeeto.io>
+ */
+class ChildRepository extends Repository
+{
+    private $customDependency;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        ClientInterface $client,
+        Factory $requestFactory,
+        ResponseMapperInterface $responseMapper,
+        $class,
+        $customDependency = null
+    ) {
+        parent::__construct($client, $requestFactory, $responseMapper, $class);
+        $this->customDependency = $customDependency;
+    }
+
+    /**
+     * Get model class this repo is working with
+     *
+     * Here for tests
+     *
+     * @return string
+     */
+    public function getModelClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * Get custom dependency
+     *
+     * Here for testing
+     *
+     * @return mixed
+     */
+    public function getCustomDependency()
+    {
+        return $this->customDependency;
+    }
+}

--- a/tests/Tystr/RestOrm/Repository/ChildRepositoryFactory.php
+++ b/tests/Tystr/RestOrm/Repository/ChildRepositoryFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tystr\RestOrm\Repository;
+
+use GuzzleHttp\ClientInterface;
+use Tystr\RestOrm\Metadata\Registry;
+use Tystr\RestOrm\Request\Factory as RequestFactory;
+use Tystr\RestOrm\Response\ResponseMapperInterface;
+
+/**
+ * A child repository factory to test that repository factories work right while extending parent
+ *
+ * @author John Pancoast <john.p@zeeto.io>
+ */
+class ChildRepositoryFactory extends RepositoryFactory
+{
+    private $customDependency;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        ClientInterface $client,
+        RequestFactory $requestFactory,
+        ResponseMapperInterface $responseMapper,
+        Registry $metadataRegistry,
+        $customRepoDependency
+    ) {
+        parent::__construct($client, $requestFactory, $responseMapper, $metadataRegistry);
+        $this->customDependency = $customRepoDependency;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function instantiateRepository($repositoryClass, $modelClass)
+    {
+        // note add'l dependency
+        return new $repositoryClass(
+            $this->client,
+            $this->requestFactory,
+            $this->responseMapper,
+            $modelClass,
+            $this->customDependency
+        );
+    }
+}


### PR DESCRIPTION
The method was incorrectly passing the repository class to the repository instead of the model class. This commit will:
- Fix the above bug
- Make the private properties protected since they can be passed in via a child anyway. This also simplifies things when overriding instantiateRepository().
- Add tests covering above scenarios
